### PR TITLE
Use richtext filter to display imported_body data

### DIFF
--- a/libraries/blog/templates/blog/blog-post.html
+++ b/libraries/blog/templates/blog/blog-post.html
@@ -17,7 +17,7 @@
 	{# handle our older imported blog posts lacking a streamfield body #}
 	{% if page.imported_body %}
 		<div class="blog-post__imported-body rich-text">
-			{{ page.imported_body|safe }}
+			{{ page.imported_body|richtext }}
 		</div>
 		{% block extra_js %}
 			{# fix Wagtail's broken handling of raw HTML links #}


### PR DESCRIPTION
The `imported_body` field is `RichTextField` so we should use the `richtext` filter instead of the `safe` filter.

The `richtext` filter will expand DB representation of links (like `<a linktype="page" id="42">hello world</a>`), embeds and other entities into proper HTML code.