### PR TITLE
Fixes the bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,7 +12,7 @@ npm run build
 # wagtail setup
 python libraries/manage.py migrate
 python libraries/manage.py createsuperuser
-python manage.py createcachetable
+python libraries/manage.py createcachetable
 
 # postgres setup
 createuser libuser

--- a/libraries/blog/migrations/0003_create_blogindex.py
+++ b/libraries/blog/migrations/0003_create_blogindex.py
@@ -23,6 +23,7 @@ def create_blogindex(apps, schema_editor):
 
     blogindex = BlogIndex(
         title="CCA Libraries Blog",
+        draft_title="CCA Libraries Blog",
         slug='blog',
         content_type=blogindex_content_type,
         depth=3,
@@ -53,7 +54,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('blog', '0002_blogindex'),
         ('home', '0002_create_homepage'),
-        ('wagtailcore', '0035_page_last_published_at'),
+        ('wagtailcore', '0040_page_draft_title'),
     ]
 
     operations = [


### PR DESCRIPTION
This fixes:

* Migration order. Previously migrations were failing because of absence of the `draft_title` field in the `Page` model
* Cache table creation. `bootstrap.sh` previously contained a wrong path to `manage.py` when calling  the `createcachetable` management command

There are some other issues: the project seems to require Node 8. I suggest adding [`.nvmrc`](https://github.com/creationix/nvm#nvmrc) into the project and run `nvm use` before `npm install` (obviously it will require developers to have `nvm` installed locally). Or even use Vagrant. Examples of Vagrant configuration can be found in other CCA project (cca.edu rebuild is one of them).